### PR TITLE
Implement Target Flag and List Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It is designed to work with [monitoring mixins](https://github.com/monitoring-mi
 **Status: Alpha**. This is a proof of concept. It will have many holes. PRs welcome.
 
 ## Authentication and Configuration
+
 This tool interacts with Grafana via its REST API. For this, you will need to establish authentication
 credentials. These are provided to `grr` via environment variables.
 
@@ -19,10 +20,17 @@ You can either provide a `GRAFANA_URL`, which can include authentication details
 * `GRAFANA_PATH`: If the Grafana instance is not hosted at the root of the domain, you can add specify a path such as `grafana`. Do not specify the initial slash.
 
 ## Commands
+
 ### grr get
 Retrieves a dashboard from Grafana, via its UID:
 ```sh
 $ grr get my-uid
+```
+
+### grr list
+List dashboard keys from file.
+```sh
+$ grr list some-mixin.libsonnet
 ```
 
 ### grr show
@@ -43,6 +51,15 @@ Uploads each dashboard rendered by the mixin to Grafana
 $ grr apply some-mixin.libsonnet
 ```
 
+## Flags
+
+### `-t, --targets strings`
+
+The `show`, `diff`, and `apply` commands accept this flag. It allows the
+targeting of dashboards by key. This can be useful if there are many dashboards
+configured in the Jsonnet file you are working with. Run `grr list` to get a
+list of the dashboard keys.
+
 ## Example
 
 Create a file, called `mydash.libsonnet`, that contains this:
@@ -50,13 +67,13 @@ Create a file, called `mydash.libsonnet`, that contains this:
 ```jsonnet
 {
   grafanaDashboards+:: {
-     "my-dash.json": {
-        "uid": "prod-overview",
-        "title": "Production Overview",
-        "tags": [ "templated" ],
-        "timezone": "browser",
-        "schemaVersion": 16,
-     },
+    'my-dash.json': {
+      uid: 'prod-overview',
+      title: 'Production Overview',
+      tags: ['templated'],
+      timezone: 'browser',
+      schemaVersion: 16,
+    },
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ grr apply some-mixin.libsonnet
 
 ## Flags
 
-### `-t, --targets strings`
+### `-t, --target strings`
 
 The `show`, `diff`, and `apply` commands accept this flag. It allows the
 targeting of dashboards by key. This can be useful if there are many dashboards

--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	rootCmd := &cli.Command{
 		Use:     "grr",
-		Short:   "Grafana Dash",
+		Short:   "Grizzly",
 		Version: Version,
 	}
 

--- a/cmd/grr/main.go
+++ b/cmd/grr/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-clix/cli"
 )
 
-// Version is the current version of the tk command.
+// Version is the current version of the grr command.
 // To be overwritten at build time
 var Version = "dev"
 
@@ -21,6 +21,7 @@ func main() {
 	// workflow commands
 	rootCmd.AddCommand(
 		getCmd(),
+		listCmd(),
 		showCmd(),
 		diffCmd(),
 		applyCmd(),

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -6,14 +6,11 @@ import (
 )
 
 func getCmd() *cli.Command {
-
 	cmd := &cli.Command{
 		Use:   "get <dashboard-uid>",
 		Short: "retrieve dashboard json",
-		Args:  cli.ArgsAny(),
 	}
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-
 		uid := args[0]
 		config, err := dash.ParseEnvironment()
 		if err != nil {
@@ -28,16 +25,15 @@ func showCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "show <jsonnet-file>",
 		Short: "render Jsonnet dashboard as json",
-		Args:  cli.ArgsAny(),
 	}
+	targets := cmd.Flags().StringSliceP("target", "t", nil, "dashboards to target")
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-
 		jsonnetFile := args[0]
 		config, err := dash.ParseEnvironment()
 		if err != nil {
 			return err
 		}
-		return dash.Show(*config, jsonnetFile)
+		return dash.Show(*config, jsonnetFile, targets)
 	}
 	return cmd
 }
@@ -46,16 +42,15 @@ func diffCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "diff <jsonnet-file>",
 		Short: "compare Jsonnet with dashboard(s) in Grafana",
-		Args:  cli.ArgsAny(),
 	}
+	targets := cmd.Flags().StringSliceP("target", "t", nil, "dashboards to target")
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-
 		jsonnetFile := args[0]
 		config, err := dash.ParseEnvironment()
 		if err != nil {
 			return err
 		}
-		return dash.Diff(*config, jsonnetFile)
+		return dash.Diff(*config, jsonnetFile, targets)
 	}
 	return cmd
 }
@@ -64,16 +59,15 @@ func applyCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "apply <jsonnet-file>",
 		Short: "render Jsonnet and push dashboard(s) to Grafana",
-		Args:  cli.ArgsAny(),
 	}
+	targets := cmd.Flags().StringSliceP("target", "t", nil, "dashboards to target")
 	cmd.Run = func(cmd *cli.Command, args []string) error {
-
 		jsonnetFile := args[0]
 		config, err := dash.ParseEnvironment()
 		if err != nil {
 			return err
 		}
-		return dash.Apply(*config, jsonnetFile)
+		return dash.Apply(*config, jsonnetFile, targets)
 	}
 	return cmd
 }

--- a/cmd/grr/workflow.go
+++ b/cmd/grr/workflow.go
@@ -21,6 +21,19 @@ func getCmd() *cli.Command {
 	return cmd
 }
 
+func listCmd() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "list <jsonnet-file>",
+		Short: "list dashboard keys from file",
+	}
+	cmd.Run = func(cmd *cli.Command, args []string) error {
+		jsonnetFile := args[0]
+
+		return dash.List(jsonnetFile)
+	}
+	return cmd
+}
+
 func showCmd() *cli.Command {
 	cmd := &cli.Command{
 		Use:   "show <jsonnet-file>",

--- a/pkg/dash/workflow.go
+++ b/pkg/dash/workflow.go
@@ -127,9 +127,9 @@ local t = %s;
 {
   [k]: { dashboard: f.grafanaDashboards[k], folderId: 0, overwrite: true}
   for k in std.filter(
-		function(n) if std.length(t) > 0 then std.member(t, n) else true,
-		std.objectFields(f.grafanaDashboards)
-	)
+    function(n) if std.length(t) > 0 then std.member(t, n) else true,
+    std.objectFields(f.grafanaDashboards)
+  )
 }`, jsonnetFile, t)
 	output, err := evalToString(jsonnet)
 	if err != nil {


### PR DESCRIPTION
Implements flag, `-t, --target strings`, in `show`, `diff`, and `apply`. Allows the dashboard targeting by key in a local Jsonnet file.

Implements `grr list`. Lists the dashboard keys of a Jsonnet file.

Closes https://github.com/malcolmholmes/grizzly/issues/2.