### PR TITLE
Simplify Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ environment variables.
 | GRAFANA\_USER | Basic auth username if applicable. | false | `api_key` |
 | GRAFANA\_TOKEN | Basic auth password or API token. | false | - |
 
-To retrieve a token in Grafana, select the configuration option on the left (the
-cog), then 'API Keys'. From there you should be able add a new key, with
-'Editor' permissions.
+See Grafana's [Authentication API
+docs](https://grafana.com/docs/grafana/latest/http_api/auth/) for more info.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,19 @@ It is designed to work with [monitoring mixins](https://github.com/monitoring-mi
 
 ## Authentication and Configuration
 
-This tool interacts with Grafana via its REST API. For this, you will need to establish authentication
-credentials. These are provided to `grr` via environment variables.
+This tool interacts with Grafana via its REST API. For this, you will need to
+establish authentication credentials. These are provided to `grr` via
+environment variables.
 
-You can either provide a `GRAFANA_URL`, which can include authentication details, or you scan specify separately:
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| GRAFANA\_URL | Fully qualified domain name of your Grafana instance. | true | - |
+| GRAFANA\_USER | Basic auth username if applicable. | false | `api_key` |
+| GRAFANA\_TOKEN | Basic auth password or API token. | false | - |
 
-* `GRAFANA_PROTOCOL`: Defaults to `https`. You can set this to `http` if you Grafana instance does not use SSL.
-* `GRAFANA_USER`: Either basic auth username, or `apikey` if using an API token.
-* `GRAFANA_TOKEN`: Either an API token, or a password for Basic auth. To retrieve a token in Grafana, select the configuration option on the left (the cog), then 'API Keys'. From there you should be able add a new key, with 'Editor' permissions.
-* `GRAFANA_HOST`: The hostname for your Grafana installation.
-* `GRAFANA_PATH`: If the Grafana instance is not hosted at the root of the domain, you can add specify a path such as `grafana`. Do not specify the initial slash.
+To retrieve a token in Grafana, select the configuration option on the left (the
+cog), then 'API Keys'. From there you should be able add a new key, with
+'Editor' permissions.
 
 ## Commands
 

--- a/pkg/dash/config.go
+++ b/pkg/dash/config.go
@@ -15,8 +15,8 @@ type Config struct {
 // ParseEnvironment parses necessary environment variables
 func ParseEnvironment() (*Config, error) {
 	var config Config
-	if gu, exists := os.LookupEnv("GRAFANA_URL"); exists {
-		u, err := url.Parse(gu)
+	if grafanaUrl, exists := os.LookupEnv("GRAFANA_URL"); exists {
+		u, err := url.Parse(grafanaUrl)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/dash/config.go
+++ b/pkg/dash/config.go
@@ -16,12 +16,12 @@ type Config struct {
 func ParseEnvironment() (*Config, error) {
 	var config Config
 	if gu, exists := os.LookupEnv("GRAFANA_URL"); exists {
-		config.GrafanaURL = gu
+		u, err := url.Parse(gu)
+		if err != nil {
+			return nil, err
+		}
+		config.GrafanaURL = u.String()
 		if token, exists := os.LookupEnv("GRAFANA_TOKEN"); exists {
-			u, err := url.Parse(config.GrafanaURL)
-			if err != nil {
-				return nil, err
-			}
 			user, exists := os.LookupEnv("GRAFANA_USER")
 			if !exists {
 				user = "api_key"

--- a/pkg/dash/config_test.go
+++ b/pkg/dash/config_test.go
@@ -1,0 +1,70 @@
+package dash
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseEnvironment(t *testing.T) {
+	tests := map[string]struct {
+		url    string
+		user   string
+		token  string
+		expect string
+		err    bool
+	}{
+		"GRAFANA_URL only": {
+			"https://my.grafana.net",
+			"",
+			"",
+			"https://my.grafana.net",
+			false,
+		},
+		"w/ token": {
+			"https://my.grafana.net",
+			"",
+			"token",
+			"https://api_key:token@my.grafana.net",
+			false,
+		},
+		"Basic auth": {
+			"https://my.grafana.net",
+			"user",
+			"pass",
+			"https://user:pass@my.grafana.net",
+			false,
+		},
+		"GRAFANA_URL blank": {
+			"",
+			"",
+			"",
+			"",
+			true,
+		},
+	}
+	for testName, test := range tests {
+		if test.url != "" {
+			os.Setenv("GRAFANA_URL", test.url)
+		} else {
+			os.Unsetenv("GRAFANA_URL")
+		}
+		if test.user != "" {
+			os.Setenv("GRAFANA_USER", test.user)
+		} else {
+			os.Unsetenv("GRAFANA_USER")
+		}
+		if test.token != "" {
+			os.Setenv("GRAFANA_TOKEN", test.token)
+		} else {
+			os.Unsetenv("GRAFANA_TOKEN")
+		}
+		t.Logf("Running test case, %q...", testName)
+		cfg, err := ParseEnvironment()
+		if err != nil && !test.err {
+			t.Errorf("Unexpected error getting Jsonnet files: %s", err)
+		}
+		if cfg != nil && cfg.GrafanaURL != test.expect {
+			t.Errorf("Expected GrafanaURL %s, got: %s", test.expect, cfg.GrafanaURL)
+		}
+	}
+}


### PR DESCRIPTION
Support only `GRAFANA_URL`, `GRAFANA_USER`, `GRAFANA_TOKEN`.

I needed to use an API key and I found the environment variables a bit confusing. Decided to take a pass at simplifying them a little bit.