### PR TITLE
Folder is Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Create a file, called `mydash.libsonnet`, that contains this:
 
 ```jsonnet
 {
+
+  grafanaDashboardFolder: 'my-folder', // optional
+
   grafanaDashboards+:: {
     'my-dash.json': {
       uid: 'prod-overview',


### PR DESCRIPTION
`apply` command looks for `grafanaDashboardFolder` field and uses the folder/dashboard search API to attempt to find a folder ID for it. If unset or folder not found, it will default to 0 which will result in dashboards being applied to the "General" folder.

Closes https://github.com/malcolmholmes/grizzly/issues/8.