### PR TITLE
Prevent panic on diff when remote dashboard is nil

### DIFF
--- a/pkg/dash/workflow.go
+++ b/pkg/dash/workflow.go
@@ -66,6 +66,9 @@ func Diff(config Config, jsonnetFile string, targets *[]string) error {
 		existingBoard, err := getDashboard(config, board.UID)
 		if err != nil {
 			return fmt.Errorf("Error retrieving dashboard %s: %v", name, err)
+		} else if existingBoard.Dashboard == nil {
+			fmt.Printf("Remote dashboard not found with UID, %s\n", board.UID)
+			continue
 		}
 		normalize(*existingBoard)
 


### PR DESCRIPTION
The `normalize` function would panic when `board.Dashboard` was nil with:

```
panic: assignment to entry in nil map
```

Closes https://github.com/malcolmholmes/grizzly/issues/6